### PR TITLE
Add a new keyloader -> env to allow for environment based keys

### DIFF
--- a/packages/asap-core/src/authenticator.ts
+++ b/packages/asap-core/src/authenticator.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import jsonWebToken, { JwtPayload, Algorithm } from 'jsonwebtoken';
 
 import axios from 'axios';
-import createPublicKeyFetcher from './fetch';
+import createPublicKeyFetcher from './fetchers/http';
 import { AsapAuthenticationError } from './errors';
 
 const ALLOWED_ALGORITHMS: Algorithm[] = [

--- a/packages/asap-core/src/fetchers/env.ts
+++ b/packages/asap-core/src/fetchers/env.ts
@@ -1,0 +1,13 @@
+export const getKey = (prefix: string, keyId: string) => {
+  const key = keyId.replace('/', '_').toUpperCase();
+  return `${prefix}${key}`;
+};
+
+export const environmentFetcher =
+  (prefix: string = 'PRIVATE_') =>
+  async (keyId: string): Promise<string> => {
+    const key = getKey(prefix, keyId);
+    return process.env[key] || '';
+  };
+
+export default environmentFetcher;

--- a/packages/asap-core/src/fetchers/http.ts
+++ b/packages/asap-core/src/fetchers/http.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import { URL } from 'url';
 import axios from 'axios';
-import cache from './cache';
-import { AsapAuthenticationError } from './errors';
+import cache from '../cache';
+import { AsapAuthenticationError } from '../errors';
 
 function parseUrlArray(array: string[]) {
   const urls = array.map(urlString => new URL(urlString));

--- a/packages/asap-core/src/index.ts
+++ b/packages/asap-core/src/index.ts
@@ -1,3 +1,5 @@
 export * from './authenticator';
 export * from './errors';
+export * from './fetchers/env';
+export * from './fetchers/http';
 export * from './generate';

--- a/packages/asap-core/test/env_test.ts
+++ b/packages/asap-core/test/env_test.ts
@@ -1,0 +1,34 @@
+import { describe, afterEach, beforeEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { getKey, environmentFetcher } from '../src/fetchers/env';
+
+describe('env', () => {
+  let jwtConfig;
+  let currentTime;
+  let time;
+
+  beforeEach(() => {
+    time = sinon.useFakeTimers(123456789 * 1000);
+  });
+
+  afterEach(() => {
+    time.restore();
+  });
+
+  describe('getKey', () => {
+    it('correclty formats env key', async () => {
+      const key = getKey('APP_', 'test/key');
+      expect(key).to.equal('APP_TEST_KEY');
+    });
+  });
+
+  describe('environmentFetcher', () => {
+    it('correclty env value', async () => {
+      process.env.APP_TEST_KEY = '123';
+      const fetcher = environmentFetcher('APP_');
+      const key = await fetcher('test/key');
+      expect(key).to.equal('123');
+    });
+  });
+});


### PR DESCRIPTION
This removes the dependency on a webserver for public key retrieval.
Useful local development or other deployment targets

