### PR TITLE
Register hapi asap as strategy

### DIFF
--- a/packages/hapi-asap/package.json
+++ b/packages/hapi-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/hapi-asap",
-  "version": "0.1.2-beta2",
+  "version": "0.1.2-beta3",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/hapi-asap/package.json
+++ b/packages/hapi-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/hapi-asap",
-  "version": "0.1.2-beta3",
+  "version": "0.1.2",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/hapi-asap/package.json
+++ b/packages/hapi-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/hapi-asap",
-  "version": "0.1.2-beta",
+  "version": "0.1.2-beta2",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/hapi-asap/src/middleware.ts
+++ b/packages/hapi-asap/src/middleware.ts
@@ -42,15 +42,17 @@ const implementation = (_server: Hapi.Server, options?: any) => {
 /**
  * Creates an hapi plugin to validate the authorization header
  * using the ASAP standard
+ * 
  *
  * @param opts AuthenticatorOptions
  *
  */
 const register = async (
   server: Hapi.Server,
-  _options: AuthenticatorOptions
+  options: AuthenticatorOptions
 ): Promise<void> => {
   server.auth.scheme('hapi-asap', implementation);
+  server.auth.strategy('hapi-asap', 'hapi-asap', options);
 };
 
 export const plugin: Hapi.Plugin<AuthenticatorOptions> = {

--- a/packages/hapi-asap/src/middleware.ts
+++ b/packages/hapi-asap/src/middleware.ts
@@ -42,7 +42,7 @@ const implementation = (_server: Hapi.Server, options?: any) => {
 /**
  * Creates an hapi plugin to validate the authorization header
  * using the ASAP standard
- * 
+ *
  *
  * @param opts AuthenticatorOptions
  *


### PR DESCRIPTION
Hapi asap register function needs to interop with hapi glue.  Currently, we cannot register it as a strategy unless glue compose runs, but any route using this strategy will fail to init.

## Changes
Registers the hapi asap middleware as a strategy `hapi-asap`