### PR TITLE
Change claims types in the express package

### DIFF
--- a/packages/express-asap/package.json
+++ b/packages/express-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/express-asap",
-  "version": "0.1.5-beta3",
+  "version": "0.1.5-beta4",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/express-asap/package.json
+++ b/packages/express-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/express-asap",
-  "version": "0.1.5-beta4",
+  "version": "0.1.5-beta5",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/express-asap/src/index.ts
+++ b/packages/express-asap/src/index.ts
@@ -8,7 +8,7 @@ declare global {
     interface Request {
       locals?: {
         [key: string]: any;
-        asapClaims?: string | JwtPayload | null;
+        asapClaims?: JwtPayload | null;
       };
     }
   }

--- a/packages/express-asap/src/middleware.ts
+++ b/packages/express-asap/src/middleware.ts
@@ -3,6 +3,7 @@ import {
   createAsapAuthenticator,
   AuthenticatorOptions,
 } from '@ordermentum/asap-core';
+import { JwtPayload } from 'jsonwebtoken';
 
 /**
  * Creates an express middleware to validate the authorization header
@@ -25,7 +26,7 @@ export function createAsapAuthenticationMiddleware(opts: AuthenticatorOptions) {
       return authenticateAsapHeader(authHeader)
         .then(asapClaims => {
           request.locals = request.locals ?? {};
-          request.locals.asapClaims = asapClaims;
+          request.locals.asapClaims = asapClaims as JwtPayload;
           next();
         })
         .catch(error => {


### PR DESCRIPTION
Asap claims are supposed to be an object cause this is how they are injected in the JWT.
The types don't reflect then and need to be typecasted. 

This PR changes the types on the express request object.