### PR TITLE
Add an option to fail early in express middlewares

### DIFF
--- a/packages/express-asap/package.json
+++ b/packages/express-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/express-asap",
-  "version": "0.1.5-beta5",
+  "version": "0.2.0-beta1",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/express-asap/src/middleware.ts
+++ b/packages/express-asap/src/middleware.ts
@@ -5,6 +5,22 @@ import {
 } from '@ordermentum/asap-core';
 import { JwtPayload } from 'jsonwebtoken';
 
+export type ExpressAsapMiddlewareOptions = AuthenticatorOptions & {
+  /**
+   * Set if you want this middleware 
+   * to invoke an error if it fails to authenticate
+   * instead of passing the request on
+   * @default false
+   * @example - Routes that use this have to check for the presence of claims on the request
+   * 
+   * //handler
+   * if(!req.locals?.asapClaims) // Can check presence of nested claims
+   *  res.sendStatus(401); 
+   * 
+   */
+  failEarly?: boolean;
+}
+
 /**
  * Creates an express middleware to validate the authorization header
  * using the ASAP standard
@@ -13,7 +29,7 @@ import { JwtPayload } from 'jsonwebtoken';
  * @returns Express middleware function
  *
  */
-export function createAsapAuthenticationMiddleware(opts: AuthenticatorOptions) {
+export function createAsapAuthenticationMiddleware(opts: ExpressAsapMiddlewareOptions) {
   const authenticateAsapHeader = createAsapAuthenticator(opts);
 
   return function asapAuthenticationMiddleware(
@@ -30,7 +46,10 @@ export function createAsapAuthenticationMiddleware(opts: AuthenticatorOptions) {
           next();
         })
         .catch(error => {
-          next(error);
+          if(opts.failEarly)
+            next(error);
+          else
+            next();
         });
     }
     return next();

--- a/packages/express-asap/src/middleware.ts
+++ b/packages/express-asap/src/middleware.ts
@@ -7,19 +7,19 @@ import { JwtPayload } from 'jsonwebtoken';
 
 export type ExpressAsapMiddlewareOptions = AuthenticatorOptions & {
   /**
-   * Set if you want this middleware 
+   * Set if you want this middleware
    * to invoke an error if it fails to authenticate
    * instead of passing the request on
    * @default false
    * @example - Routes that use this have to check for the presence of claims on the request
-   * 
+   *
    * //handler
    * if(!req.locals?.asapClaims) // Can check presence of nested claims
-   *  res.sendStatus(401); 
-   * 
+   *  res.sendStatus(401);
+   *
    */
   failEarly?: boolean;
-}
+};
 
 /**
  * Creates an express middleware to validate the authorization header
@@ -29,7 +29,9 @@ export type ExpressAsapMiddlewareOptions = AuthenticatorOptions & {
  * @returns Express middleware function
  *
  */
-export function createAsapAuthenticationMiddleware(opts: ExpressAsapMiddlewareOptions) {
+export function createAsapAuthenticationMiddleware(
+  opts: ExpressAsapMiddlewareOptions
+) {
   const authenticateAsapHeader = createAsapAuthenticator(opts);
 
   return function asapAuthenticationMiddleware(
@@ -46,10 +48,8 @@ export function createAsapAuthenticationMiddleware(opts: ExpressAsapMiddlewareOp
           next();
         })
         .catch(error => {
-          if(opts.failEarly)
-            next(error);
-          else
-            next();
+          if (opts.failEarly) next(error);
+          else next();
         });
     }
     return next();


### PR DESCRIPTION
Context: 
Using this middleware without breaking the middleware flow in existing apps is vital. Currently it defaults to invoking the error handler when asap fails. We would be, instead, verifying the presence of certain claims on the req object (`req.locals`)

This PR adds an option `failEarly` as an option to fail if asap auth fails and defaults it to false.