### PR TITLE
DEVOPS-966 revise AuthHeaderConfig type definition

### DIFF
--- a/packages/asap-core/src/generate.ts
+++ b/packages/asap-core/src/generate.ts
@@ -14,6 +14,7 @@ function assertDefined(value: string | null | undefined, message: string) {
 }
 
 type AuthHeaderConfigBase = {
+  privateKey?: string;
   keyId: string;
   issuer: string;
   audience: string;
@@ -21,27 +22,22 @@ type AuthHeaderConfigBase = {
   tokenMaxAgeMs?: number;
   subject?: string;
   additionalClaims?: any;
+  /**
+   * Insecure mode forces the generator to use a static private key for encryption
+   * This mode helps services to test authentication flows
+   * @default false
+   */
+  insecureMode?: boolean;
 };
 
 interface AuthHeaderConfigInsecure extends AuthHeaderConfigBase {
-  privateKey?: string;
-  /**
-   * Insecure mode forces the generator to use a static private key for encryption
-   * This mode helps services to test authentication flows
-   * @default false
-   */
   insecureMode: true;
-};
+}
 
 interface AuthHeaderConfigSecure extends AuthHeaderConfigBase {
-  privateKey: string;
-  /**
-   * Insecure mode forces the generator to use a static private key for encryption
-   * This mode helps services to test authentication flows
-   * @default false
-   */
   insecureMode?: false;
-};
+  privateKey: string;
+}
 
 type AuthHeaderConfig = AuthHeaderConfigSecure | AuthHeaderConfigInsecure;
 

--- a/packages/asap-core/src/generate.ts
+++ b/packages/asap-core/src/generate.ts
@@ -39,7 +39,9 @@ interface AuthHeaderConfigSecure extends AuthHeaderConfigBase {
   privateKey: string;
 }
 
-type AuthHeaderConfig = AuthHeaderConfigSecure | AuthHeaderConfigInsecure;
+export type AuthHeaderConfig =
+  | AuthHeaderConfigSecure
+  | AuthHeaderConfigInsecure;
 
 export function createAuthHeaderGenerator(jwtConfig: AuthHeaderConfig) {
   if (jwtConfig.insecureMode) jwtConfig.privateKey = testPrivateKey; // eslint-disable-line no-param-reassign

--- a/packages/asap-core/src/generate.ts
+++ b/packages/asap-core/src/generate.ts
@@ -12,8 +12,8 @@ function assertDefined(value: string | null | undefined, message: string) {
     throw new Error(message);
   }
 }
-export type AuthHeaderConfig = {
-  privateKey: string;
+
+type AuthHeaderConfigBase = {
   keyId: string;
   issuer: string;
   audience: string;
@@ -21,13 +21,30 @@ export type AuthHeaderConfig = {
   tokenMaxAgeMs?: number;
   subject?: string;
   additionalClaims?: any;
+};
+
+interface AuthHeaderConfigInsecure extends AuthHeaderConfigBase {
+  privateKey?: string;
   /**
    * Insecure mode forces the generator to use a static private key for encryption
    * This mode helps services to test authentication flows
    * @default false
    */
-  insecureMode?: boolean;
+  insecureMode: true;
 };
+
+interface AuthHeaderConfigSecure extends AuthHeaderConfigBase {
+  privateKey: string;
+  /**
+   * Insecure mode forces the generator to use a static private key for encryption
+   * This mode helps services to test authentication flows
+   * @default false
+   */
+  insecureMode?: false;
+};
+
+type AuthHeaderConfig = AuthHeaderConfigSecure | AuthHeaderConfigInsecure;
+
 export function createAuthHeaderGenerator(jwtConfig: AuthHeaderConfig) {
   if (jwtConfig.insecureMode) jwtConfig.privateKey = testPrivateKey; // eslint-disable-line no-param-reassign
   assertDefined(jwtConfig.privateKey, 'jwtConfig.privateKey must be set');
@@ -35,7 +52,7 @@ export function createAuthHeaderGenerator(jwtConfig: AuthHeaderConfig) {
   assertDefined(jwtConfig.issuer, 'jwtConfig.issuer must be set');
   assertDefined(jwtConfig.audience, 'jwtConfig.audience must be set');
 
-  const privateKey = jwtConfig.privateKey
+  const privateKey = (jwtConfig.privateKey as string)
     .replace(/\\n/g, '\n')
     .replace(/"/g, '');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,6 +585,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@ordermentum/asap-core@*":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@ordermentum/asap-core/-/asap-core-0.1.7.tgz#fd7cabc0cec15db7bc69a003d1cfa95301c901fc"
+  integrity sha512-R0B5p4PRJq0xnjj3Zr9d+Z2t6Cylj2R3WBAsRS9bonAfLylsUZDoKcC4PgJcFHhLvqBbETLjVPJv8fOdUF1vmQ==
+  dependencies:
+    axios "^0.26.1"
+    express "^4.17.3"
+    jsonwebtoken "^8.5.1"
+    node-cache "^5.1.2"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"


### PR DESCRIPTION
#### Description

This revises the AuthHeaderConfig type definition to account for the fact that the privateKey is ignored when insecureConfig is true


----
#### PR Type

_Check one or more and add the corresponding number of reviewers_

- [ ] Bugfix or minor change _(1)_
- [ ] Feature _(2)_
- [ ] Breaking change (existing functionality no longer works as expected) _(2)_
- [ ] Critical impact (security, payments or critical functionality) _(2+CTO)_

----
#### Changes

_List the main changes in this PR. Include screenshots if necessary._

----

#### Acceptance Criteria

_How can we test that this meets the requirements of the ticket?_

----

#### Checklist:

- [ ] Tests – Have you added or edited the test cases?
- [ ] Context – Have you tested this with a non-admin user?
- [ ] Rebase – Has this PR been rebased against `develop`?
- [ ] Feature Flag - If this is a new feature, does it have a feature flag?
- [ ] Release - Can this be released to production once tested?
