### PR TITLE
We currently create a client in each service.

### DIFF
--- a/packages/axios-asap/package.json
+++ b/packages/axios-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/axios-asap",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "main": "build/index.js",
   "files": [
     "build/*"

--- a/packages/axios-asap/src/index.ts
+++ b/packages/axios-asap/src/index.ts
@@ -2,17 +2,76 @@ import {
   createAuthHeaderGenerator,
   AuthHeaderConfig,
 } from '@ordermentum/asap-core';
-import { AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import http from 'http';
+import https from 'https';
 
 export const createAsapInterceptor = (authConfig: AuthHeaderConfig) => {
-  const headerGenerator = createAuthHeaderGenerator(authConfig);
-
+  const headerGenerator = createAuthHeaderGenerator({
+    ...authConfig,
+  });
   return (config: AxiosRequestConfig) => {
     const header = headerGenerator();
     const headers = config.headers ?? {};
     headers.Authorization = header;
     return { ...config, headers };
   };
+};
+
+export const serviceToClientMap = new Map<string, AxiosInstance>();
+
+const getDefaultAxiosConfig = (): AxiosRequestConfig => ({
+  httpAgent: new http.Agent({ keepAlive: true }),
+  httpsAgent: new https.Agent({ keepAlive: true }),
+});
+
+export type Options = {
+  issuer: string;
+  service: string;
+  publicKey: string;
+  privateKey: string;
+  cache?: boolean;
+};
+
+export const createClient = (
+  { issuer, service, publicKey, privateKey }: Options,
+  authConfig: Pick<
+    AuthHeaderConfig,
+    'insecureMode' | 'additionalClaims' | 'tokenExpiryMs'
+  > = {},
+  axiosOptions: AxiosRequestConfig = {}
+) => {
+  const DEFAULT_TOKEN_EXPIRY_MS = 60 * 5 * 1000; // 5 minute expiry
+  const issuerServiceKey = `${issuer}:${service}`;
+
+  // Check if cache has a client
+  if (!authConfig.insecureMode && serviceToClientMap.has(issuerServiceKey))
+    return serviceToClientMap.get(issuerServiceKey)!;
+
+  const axiosCreateOpts = {
+    ...getDefaultAxiosConfig(),
+    ...axiosOptions,
+  };
+
+  if (!privateKey && !authConfig.insecureMode)
+    return axios.create(axiosCreateOpts);
+
+  // Create an interceptor for the service
+  const asapInterceptor = createAsapInterceptor({
+    ...authConfig,
+    privateKey,
+    keyId: `${issuer}/${publicKey}`,
+    issuer,
+    audience: service,
+    tokenExpiryMs: DEFAULT_TOKEN_EXPIRY_MS,
+  });
+
+  const client = axios.create(axiosCreateOpts);
+  // @ts-ignore
+  client.interceptors.request.use(asapInterceptor);
+  serviceToClientMap.set(issuerServiceKey, client);
+
+  return client;
 };
 
 export default createAsapInterceptor;

--- a/packages/axios-asap/test/index_test.ts
+++ b/packages/axios-asap/test/index_test.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import moxios from 'moxios';
 import { expect } from 'chai';
 import { privateKeyPem } from '@ordermentum/asap-test-helpers';
-import { createAsapInterceptor } from '../src';
+import { createAsapInterceptor, createClient } from '../src';
 
 describe('createAuthHeaderGenerator', () => {
   let jwtConfig;
@@ -28,7 +28,36 @@ describe('createAuthHeaderGenerator', () => {
 
     const res = await client.get('/say/hello');
     expect(res.status).to.equal(200);
-    expect(Object.keys(res.config.headers)).to.include('Authorization');
-    expect(res.config.headers.Authorization).to.include('Bearer');
+    expect(Object.keys(res?.config?.headers ?? {})).to.include('Authorization');
+    expect(res?.config?.headers?.Authorization).to.include('Bearer');
+  });
+
+  it('creates a client', async () => {
+    const client = createClient(
+      {
+        service: 'the-keyid',
+        issuer: 'an-issuer',
+        publicKey: 'public-key',
+        privateKey: privateKeyPem,
+      },
+      {
+        insecureMode: false,
+        additionalClaims: {
+          admin: true,
+          userId: '123',
+        },
+      }
+    );
+
+    moxios.install(client);
+    moxios.stubRequest('/say/hello', {
+      status: 200,
+      responseText: 'hello',
+    });
+
+    const res = await client.get('/say/hello');
+    expect(res.status).to.equal(200);
+    expect(Object.keys(res?.config?.headers ?? {})).to.include('Authorization');
+    expect(res?.config?.headers?.Authorization).to.include('Bearer');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,16 +585,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@ordermentum/asap-core@*":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@ordermentum/asap-core/-/asap-core-0.1.7.tgz#fd7cabc0cec15db7bc69a003d1cfa95301c901fc"
-  integrity sha512-R0B5p4PRJq0xnjj3Zr9d+Z2t6Cylj2R3WBAsRS9bonAfLylsUZDoKcC4PgJcFHhLvqBbETLjVPJv8fOdUF1vmQ==
-  dependencies:
-    axios "^0.26.1"
-    express "^4.17.3"
-    jsonwebtoken "^8.5.1"
-    node-cache "^5.1.2"
-
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"


### PR DESCRIPTION
This moves the common code back into the axios-asap package.

This offers the same options

- keep alive enabled on clients
- client caching
