### PR TITLE
Export types and register methods from hapi asap package

### DIFF
--- a/packages/hapi-asap/package.json
+++ b/packages/hapi-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/hapi-asap",
-  "version": "0.1.2",
+  "version": "0.1.3-beta",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/hapi-asap/package.json
+++ b/packages/hapi-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/hapi-asap",
-  "version": "0.1.3-beta1",
+  "version": "0.1.3",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/hapi-asap/package.json
+++ b/packages/hapi-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/hapi-asap",
-  "version": "0.1.3-beta",
+  "version": "0.1.3-beta1",
   "main": "build/index.js",
   "license": "MIT",
   "files": [

--- a/packages/hapi-asap/src/middleware.ts
+++ b/packages/hapi-asap/src/middleware.ts
@@ -47,10 +47,10 @@ const implementation = (_server: Hapi.Server, options?: any) => {
  * @param opts AuthenticatorOptions
  *
  */
-const register = async (
+const register = (
   server: Hapi.Server,
   options: AuthenticatorOptions
-): Promise<void> => {
+) => {
   server.auth.scheme('hapi-asap', implementation);
   server.auth.strategy('hapi-asap', 'hapi-asap', options);
 };

--- a/packages/hapi-asap/src/middleware.ts
+++ b/packages/hapi-asap/src/middleware.ts
@@ -55,9 +55,15 @@ const register = async (
   server.auth.strategy('hapi-asap', 'hapi-asap', options);
 };
 
-export const plugin: Hapi.Plugin<AuthenticatorOptions> = {
+const plugin: Hapi.Plugin<AuthenticatorOptions> = {
   register,
   pkg: { name: 'ASAP Authentication', version: '0.1.0' },
 };
+
+export {
+  register, 
+  AuthenticatorOptions,
+  plugin
+}
 
 export default plugin;


### PR DESCRIPTION
Exporting `register` method and `options` types from the hapi asap plugin so it can be used in the auth middleware package.