### PR TITLE
Have the client cache use headers as a key

### DIFF
--- a/packages/axios-asap/package.json
+++ b/packages/axios-asap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordermentum/axios-asap",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "build/index.js",
   "files": [
     "build/*"

--- a/packages/axios-asap/test/index_test.ts
+++ b/packages/axios-asap/test/index_test.ts
@@ -60,4 +60,96 @@ describe('createAuthHeaderGenerator', () => {
     expect(Object.keys(res?.config?.headers ?? {})).to.include('Authorization');
     expect(res?.config?.headers?.Authorization).to.include('Bearer');
   });
+
+  it('the cache is aware of headers and returns different clients for them', () => {
+    const client1 = createClient(
+      {
+        service: 'the-keyid',
+        issuer: 'an-issuer',
+        publicKey: 'public-key',
+        privateKey: privateKeyPem,
+      },
+      {
+        insecureMode: false,
+        additionalClaims: {
+          admin: true,
+          userId: '123',
+        },
+      },
+      {
+        headers: {
+          'x-custom-header': '1',
+        },
+      }
+    );
+    const client2 = createClient(
+      {
+        service: 'the-keyid',
+        issuer: 'an-issuer',
+        publicKey: 'public-key',
+        privateKey: privateKeyPem,
+      },
+      {
+        insecureMode: false,
+        additionalClaims: {
+          admin: true,
+          userId: '123',
+        },
+      },
+      {
+        headers: {
+          'x-custom-header': '2',
+        },
+      }
+    );
+    expect(client1).to.not.equal(client2);
+    expect(client1.defaults.headers['x-custom-header']).to.equal('1');
+    expect(client2.defaults.headers['x-custom-header']).to.equal('2');
+  });
+
+  it('the cache returns the same client if the headers match', () => {
+    const client1 = createClient(
+      {
+        service: 'the-keyid',
+        issuer: 'an-issuer',
+        publicKey: 'public-key',
+        privateKey: privateKeyPem,
+      },
+      {
+        insecureMode: false,
+        additionalClaims: {
+          admin: true,
+          userId: '123',
+        },
+      },
+      {
+        headers: {
+          'x-custom-header': '1',
+        },
+      }
+    );
+    const client2 = createClient(
+      {
+        service: 'the-keyid',
+        issuer: 'an-issuer',
+        publicKey: 'public-key',
+        privateKey: privateKeyPem,
+      },
+      {
+        insecureMode: false,
+        additionalClaims: {
+          admin: true,
+          userId: '123',
+        },
+      },
+      {
+        headers: {
+          'x-custom-header': '1',
+        },
+      }
+    );
+    expect(client1).to.equal(client2);
+    expect(client1.defaults.headers['x-custom-header']).to.equal('1');
+    expect(client2.defaults.headers['x-custom-header']).to.equal('1');
+  })
 });


### PR DESCRIPTION
If other custom headers are set as part of client creation it should get used in the client cache so that we return the correctly configured client each time.


----
#### PR Type

_Check one or more and add the corresponding number of reviewers_

- [X] Bugfix or minor change _(1)_
- [ ] Feature _(2)_
- [ ] Breaking change (existing functionality no longer works as expected) _(2)_
- [ ] Critical impact (security, payments or critical functionality) _(2+CTO)_

